### PR TITLE
Update telegram channel python and add readme hints for developement and deletion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Some options can be set via an environment variable (real or [dotenv](https://gi
         -p qwerty123 \
         ...
     ```
+## Deleting messages
+Please be careful with this setup ...
+to delete mails seen by the bot,
+add the following code right at the end of the mail loop ( and possibly fix indentation):
+```
+            self.mailbox.delete([msg.uid])
+        self.mailbox.expunge()
+```
 ## Developer hints
 
 When using a non-docker or git version ( e.g. in venv), the required packages can be obtained with:

--- a/README.md
+++ b/README.md
@@ -58,3 +58,9 @@ Some options can be set via an environment variable (real or [dotenv](https://gi
         -p qwerty123 \
         ...
     ```
+## Developer hints
+
+When using a non-docker or git version ( e.g. in venv), the required packages can be obtained with:
+```
+pip3 install sentry_sdk imap_tools telegram pyyaml click requests dotenv bs4   python-telegram-bot
+```

--- a/imapmon/channels/tg.py
+++ b/imapmon/channels/tg.py
@@ -1,7 +1,11 @@
 from click import BadOptionUsage
 from bs4 import BeautifulSoup
 from imap_tools import MailMessage
-from telegram import Bot, ParseMode
+#from telegram import Bot, ParseMode
+#as per Version 20 you need to use: (https://stackoverflow.com/a/74180161)
+from telegram import Bot
+from telegram.constants import ParseMode
+
 
 from imapmon.settings import Settings
 from imapmon.channels.base import BaseChannel

--- a/imapmon/channels/tg.py
+++ b/imapmon/channels/tg.py
@@ -5,7 +5,7 @@ from imap_tools import MailMessage
 #as per Version 20 you need to use: (https://stackoverflow.com/a/74180161)
 from telegram import Bot
 from telegram.constants import ParseMode
-
+import asyncio
 
 from imapmon.settings import Settings
 from imapmon.channels.base import BaseChannel
@@ -51,9 +51,9 @@ class TelegramChannel(BaseChannel):
             f'```\n{self.clean_string(message_body)}\n```'
         )
 
-        self.bot.send_message(
+        asyncio.run(self.bot.send_message(
             chat_id=self.settings.telegram_chat_id,
             text=telegram_msg,
             parse_mode=ParseMode.MARKDOWN_V2,
             disable_web_page_preview=True
-        )
+        ))


### PR DESCRIPTION
did not work in python-3.9 when not using docker
```
ImportError: cannot import name 'ParseMode' from 'telegram'
```
https://stackoverflow.com/questions/69155789/importerror-cannot-import-name-parsemode-from-telegram

after implementing it , asyncio needs to be used for message sending

added hints in readme to deploy non-docker environment quickly
added hint to implement mail deletion